### PR TITLE
Define a ccls-get-initialization-options-function option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It leverages [lsp-mode](https://github.com/emacs-lsp/lsp-mode), but also provide
 * skipped ranges (e.g. a `#if false` region)
 * cross references: `$ccls/inheritance` `$ccls/call` `$ccls/vars`
 
-More on <https://github.com/MaskRay/ccls/wiki/Emacs>
+More on <https://github.com/MaskRay/ccls/wiki/lsp-mode>
 
 ## Quickstart
 

--- a/ccls.el
+++ b/ccls.el
@@ -68,6 +68,16 @@
   "initializationOptions"
   :group 'ccls)
 
+(defcustom ccls-get-initialization-options-function
+  #'ccls-get-initialization-options
+  "Function to get initialization options"
+  :type 'function
+  :group 'ccls)
+
+; The default function simply returns ccls-initialization-options
+(defun ccls-get-initialization-options ()
+  ccls-initialization-options)
+
 ;; ---------------------------------------------------------------------
 ;;   Other ccls-specific methods
 ;; ---------------------------------------------------------------------
@@ -138,7 +148,7 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
   :notification-handlers
   (lsp-ht ("$ccls/publishSkippedRanges" #'ccls--publish-skipped-ranges)
           ("$ccls/publishSemanticHighlight" #'ccls--publish-semantic-highlight))
-  :initialization-options (lambda () ccls-initialization-options)
+  :initialization-options ccls-get-initialization-options-function
   :library-folders-fn nil))
 
 (provide 'ccls)


### PR DESCRIPTION
This is to allow the ccls initialization options to vary from project
to project (in my case some have the compile_commands.json file in a
build directory, so for those I want the options to be
'(:compilationDatabaseDirectory "build")).