### PR TITLE
Add function `ccls--get-initialization-options` to provide initializa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It leverages [lsp-mode](https://github.com/emacs-lsp/lsp-mode), but also provide
 * skipped ranges (e.g. a `#if false` region)
 * cross references: `$ccls/inheritance` `$ccls/call` `$ccls/vars`
 
-More on <https://github.com/MaskRay/ccls/wiki/Emacs>
+More on <https://github.com/MaskRay/ccls/wiki/lsp-mode>
 
 ## Quickstart
 

--- a/ccls.el
+++ b/ccls.el
@@ -130,6 +130,12 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
 
 (advice-add 'lsp--suggest-project-root :before-until #'ccls--suggest-project-root)
 
+
+(defun ccls--get-initialization-options ()
+  "Simple function to return initializationOptions for ccls.
+User can rewrite this function to provide some project-specific options."
+  ccls-initialization-options)
+
 (lsp-register-client
  (make-lsp-client
   :new-connection (lsp-stdio-connection (lambda () (cons ccls-executable ccls-args)))
@@ -139,7 +145,7 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
   :notification-handlers
   (lsp-ht ("$ccls/publishSkippedRanges" #'ccls--publish-skipped-ranges)
           ("$ccls/publishSemanticHighlight" #'ccls--publish-semantic-highlight))
-  :initialization-options (lambda () ccls-initialization-options)
+  :initialization-options (lambda () (ccls--get-initialization-options))
   :library-folders-fn nil))
 
 (provide 'ccls)

--- a/ccls.el
+++ b/ccls.el
@@ -125,7 +125,8 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
 
 (defun ccls--suggest-project-root ()
   (and (memq major-mode '(c-mode c++-mode cuda-mode objc-mode))
-       (locate-dominating-file default-directory ".ccls-root")))
+       (when-let (dir (locate-dominating-file default-directory ".ccls-root"))
+         (expand-file-name dir))))
 
 (advice-add 'lsp--suggest-project-root :before-until #'ccls--suggest-project-root)
 


### PR DESCRIPTION
…tionOptions.

User can rewrite this function to provide some **project-specific** options.

In my case, I rewrite this function to:

* read project-specific options from `.ccls-root`
* set proper `compilationDatabaseDirectory`

Here is an example:

```
  (defun yc/ccls--get-initialization-options-adv (&rest args)
    "Advice for 'ccls--get-initialization-options'.
Call FUNC which is 'ccls--get-initialization-options with ARGS."
    (let* ((root-dir (locate-dominating-file default-directory ".ccls-root"))
           (root-file (and root-dir (concat root-dir ".ccls-root"))))
      (setq ccls-initialization-options '(:index (:blacklist ("fake_blacklist"))))
      (when root-file
        ;; loading project specific settings from .ccls-root
        (if (and root-file
                 (> (file-attribute-size (file-attributes root-file)) 10))
            (with-temp-buffer
              (insert-file-contents root-file)
              (eval-buffer)
              (message "Loaded project configuration from %s" root-file)))

        ;; guessing compliation database....
        (PDEBUG "Before advice" ccls-initialization-options)
        (unless (member :compilationDatabaseDirectory ccls-initialization-options)
          (catch 'p-found

            (dolist (build '("build" "cmake_build_Debug" "cmake_build_Release"))
              (when (file-exists-p (format "%s/%s/compile_commands.json" root-dir build))
                (push (format "%s/%s/" root-dir build) ccls-initialization-options)
                (push :compilationDatabaseDirectory ccls-initialization-options)
                (throw 'p-found t))))))
      ccls-initialization-options))

  (advice-add 'ccls--get-initialization-options :around
              #'yc/ccls--get-initialization-options-adv)
```