### PR TITLE
Add library folders

### DIFF
--- a/ccls.el
+++ b/ccls.el
@@ -49,6 +49,12 @@
 ;;   Customization
 ;; ---------------------------------------------------------------------
 
+(defcustom ccls-library-directories '("/usr/include/")
+  "List of directories which will be considered to be libraries."
+  :risky t
+  :type '(repeat string)
+  :group 'ccls)
+
 (defcustom ccls-executable
   "ccls"
   "Path of the ccls executable."
@@ -146,7 +152,7 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
   (lsp-ht ("$ccls/publishSkippedRanges" #'ccls--publish-skipped-ranges)
           ("$ccls/publishSemanticHighlight" #'ccls--publish-semantic-highlight))
   :initialization-options (lambda () ccls-initialization-options)
-  :library-folders-fn nil))
+  :library-folders-fn (lambda (_workspace) ccls-library-directories)))
 
 (provide 'ccls)
 ;;; ccls.el ends here


### PR DESCRIPTION
It considers files in these folders as part of the active lsp workspace. Right now if you do "lsp-find-definition" and it goes to a header file in system include path, then you cant use "lsp-find-definition" in that file as lsp isnt working there. This fixes it