### PR TITLE
Change tree characters to ones that are available in more fonts

### DIFF
--- a/ccls-call-hierarchy.el
+++ b/ccls-call-hierarchy.el
@@ -114,7 +114,7 @@
        (propertize (format " (%s:%s)"
                            (file-name-nondirectory (car (ccls-tree-node-location node)))
                            (gethash "line" (cdr (ccls-tree-node-location node))))
-                   'face 'ccls-mode-line-face)))))
+                   'face 'ccls-tree-mode-line-face)))))
 
 (defun ccls-call-hierarchy (callee)
   (interactive "P")

--- a/ccls-tree.el
+++ b/ccls-tree.el
@@ -167,10 +167,10 @@
   (let* ((padding (if (= depth 0) "" (make-string (* 2 (- depth 1)) ?\ )))
          (symbol (if (= depth 0)
                      (if (ccls-tree-node-parent node)
-                         "⏴ "
+                         "◀ "
                        "")
                    (if (ccls-tree-node-has-children node)
-                       (if (ccls-tree-node-expanded node) "└⏷" "└⏵")
+                       (if (ccls-tree-node-expanded node) "▶ " "▼ ")
                      (if (eq number (- nchildren 1)) "└╸" "├╸")))))
     (concat padding (propertize symbol 'face 'ccls-tree-icon-face))))
 


### PR DESCRIPTION
The characters currently used are not available on any of the fonts I usually use meaning they draw as boxes with hex letters in emacs. I tracked down what I think are equivalent characters that are available in all of the fonts I use (so I suspect in many more fonts as well).

