### PR TITLE
Ignore `-working-directory` option in `ccls-preprocess-file`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It leverages [lsp-mode](https://github.com/emacs-lsp/lsp-mode), but also provide
 * skipped ranges (e.g. a `#if false` region)
 * cross references: `$ccls/inheritance` `$ccls/call` `$ccls/vars`
 
-More on <https://github.com/MaskRay/ccls/wiki/Emacs>
+More on <https://github.com/MaskRay/ccls/wiki/lsp-mode>
 
 ## Quickstart
 

--- a/ccls.el
+++ b/ccls.el
@@ -125,7 +125,8 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
 
 (defun ccls--suggest-project-root ()
   (and (memq major-mode '(c-mode c++-mode cuda-mode objc-mode))
-       (locate-dominating-file default-directory ".ccls-root")))
+       (when-let (dir (locate-dominating-file default-directory ".ccls-root"))
+         (expand-file-name dir))))
 
 (advice-add 'lsp--suggest-project-root :before-until #'ccls--suggest-project-root)
 

--- a/ccls.el
+++ b/ccls.el
@@ -92,6 +92,7 @@
                                (cond
                                 ((string= arg "-o") (cl-incf i))
                                 ((string-match-p "\\`-o.+" arg))
+                                ((string-match-p "\\`-working-directory=.+" arg))
                                 (t (push arg ret))))
                              (cl-incf i))
                            (nreverse ret))))


### PR DESCRIPTION

GCC does not support this option, and preprocess works for clang without
this option too.