### PR TITLE
*fix xref--show-xrefs take fetcher function for first param in Emacs 27

### DIFF
--- a/ccls-code-lens.el
+++ b/ccls-code-lens.el
@@ -68,7 +68,7 @@
       (lambda () (interactive)
         (when-let ((xrefs (lsp--locations-to-xref-items
                            (lsp--send-execute-command (gethash "command" command) (gethash "arguments" command)))))
-          (xref--show-xrefs xrefs nil))))
+          (xref--show-xrefs (if (functionp 'xref--create-fetcher)(-const xrefs) xrefs) nil))))
     (propertize (concat lpad (gethash "title" command) rpad)
                 'face 'ccls-code-lens-face
                 'mouse-face 'ccls-code-lens-mouse-face


### PR DESCRIPTION
In Emacs 27 xref--show-xrefs take fetcher function for first param, so when click on link with references in code lens it will rise assert.