### PR TITLE
Replace (require 'lsp) with (require 'lsp-mode)

### DIFF
--- a/ccls-common.el
+++ b/ccls-common.el
@@ -24,7 +24,7 @@
 ;;; Code:
 
 (require 'cc-mode)
-(require 'lsp)
+(require 'lsp-mode)
 (require 'cl-lib)
 (require 'seq)
 (require 'subr-x)


### PR DESCRIPTION
https://github.com/emacs-lsp/lsp-mode/blob/36799a7a42b84c549a64479282bfb9b16cd865b4/lsp.el#L4

fix lsp require warning