### PR TITLE
lsp-interface for semantic highlighting must be eval-and-compile

### DIFF
--- a/ccls-semantic-highlight.el
+++ b/ccls-semantic-highlight.el
@@ -178,9 +178,9 @@ If nil, disable semantic highlight."
   (lsp-interface
    (CclsLR (:L :R) nil)
    (CclsSemanticHighlight (:uri :symbols) nil)
-   (CclsSkippedRanges (:uri :skippedRanges) nil)))
-(lsp-interface
- (CclsSemanticHighlightSymbol (:id :parentKind :kind :storage :ranges) nil))
+   (CclsSkippedRanges (:uri :skippedRanges) nil))
+  (lsp-interface
+   (CclsSemanticHighlightSymbol (:id :parentKind :kind :storage :ranges) nil)))
 
 (defun ccls--clear-sem-highlights ()
   "."


### PR DESCRIPTION
This continues the fix for #92 and addresses the spin-off issue discussed in #91.