### PR TITLE
Don't use `lsp-execute-command'

### DIFF
--- a/ccls.el
+++ b/ccls.el
@@ -145,11 +145,10 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
                                 ccls-root-files))
          (expand-file-name dir))))
 
-(cl-defmethod lsp-execute-command
-  ((_server (eql ccls)) (command (eql ccls.xref)) arguments)
+(lsp-defun ccls--show-xrefs ((&Command :arguments?))
   (when-let ((xrefs (lsp--locations-to-xref-items
                      (lsp--send-execute-command command arguments))))
-    (xref--show-xrefs xrefs nil)))
+    (lsp-show-xrefs xrefs nil t)))
 
 (advice-add 'lsp--suggest-project-root :before-until #'ccls--suggest-project-root)
 
@@ -162,6 +161,7 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
   :notification-handlers
   (lsp-ht ("$ccls/publishSkippedRanges" #'ccls--publish-skipped-ranges)
           ("$ccls/publishSemanticHighlight" #'ccls--publish-semantic-highlight))
+  :action-handlers (lsp-ht ("ccls.xref" #'ccls--show-xrefs))
   :initialization-options (lambda () ccls-initialization-options)
   :library-folders-fn ccls-library-folders-fn))
 

--- a/ccls.el
+++ b/ccls.el
@@ -145,9 +145,9 @@ DIRECTION can be \"D\", \"L\", \"R\" or \"U\"."
                                 ccls-root-files))
          (expand-file-name dir))))
 
-(lsp-defun ccls--show-xrefs ((&Command :arguments?))
+(lsp-defun ccls--show-xrefs ((&Command :command :arguments?))
   (when-let ((xrefs (lsp--locations-to-xref-items
-                     (lsp--send-execute-command command arguments))))
+                     (lsp--send-execute-command command arguments?))))
     (lsp-show-xrefs xrefs nil t)))
 
 (advice-add 'lsp--suggest-project-root :before-until #'ccls--suggest-project-root)


### PR DESCRIPTION
That function is a liability and needs to be eliminated; use :action-handlers
instead.

See the discussion in https://github.com/emacs-lsp/lsp-mode/pull/2299 for why this is necessary.